### PR TITLE
views/contact_us: use email input type

### DIFF
--- a/app/views/contact_us/new.html.erb
+++ b/app/views/contact_us/new.html.erb
@@ -20,7 +20,7 @@
     <div class='row'>
       <%= label_tag :email, 'Your Email' %>
       <br />
-      <%= text_field_tag :email, nil, required: 'required', class: contact_us_fields_class %>
+      <%= email_field_tag :email, nil, required: 'required', class: contact_us_fields_class %>
     </div>
 
     <div class='row invisible'>


### PR DESCRIPTION
For browsers that validate email addresses (basically all but Safari), this prevents invalid addresses being sent to Rails.